### PR TITLE
[FIX] Error: could not determine PostgreSQL version from '10.0'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,12 +11,12 @@ lxml==3.5.0
 Mako==1.0.4
 MarkupSafe==0.23
 mock==2.0.0
-ofxparse==0.15
+ofxparse==0.16
 passlib==1.6.5
 Pillow==3.4.1
 psutil==4.3.1
 psycogreen==1.0
-psycopg2==2.6.2
+psycopg2==2.7.1
 pydot==1.2.3
 pyparsing==2.1.10
 pyPdf==1.13
@@ -39,6 +39,7 @@ Werkzeug==0.11.11
 wsgiref==0.1.2
 XlsxWriter==0.9.3
 xlwt==1.1.2
+xlrd==1.0.0
 
 # for https://github.com/OCA/server-tools/tree/10.0/auth_signup_verify_email
 validate_email==1.3


### PR DESCRIPTION
This is mainly to fix below build error:

```
Collecting psycopg2==2.6.2 (from -r /opt/requirements.txt (line 19))

  Downloading psycopg2-2.6.2.tar.gz (376kB)

    Complete output from command python setup.py egg_info:

    running egg_info
    creating pip-egg-info/psycopg2.egg-info
    writing pip-egg-info/psycopg2.egg-info/PKG-INFO
    writing top-level names to pip-egg-info/psycopg2.egg-info/top_level.txt
    writing dependency_links to pip-egg-info/psycopg2.egg-info/dependency_links.txt
    writing manifest file 'pip-egg-info/psycopg2.egg-info/SOURCES.txt'
    warning: manifest_maker: standard file '-c' not found
    
    Error: could not determine PostgreSQL version from '10.0'
    
    ----------------------------------------

[91mCommand "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-XQrBah/psycopg2/
[0m
Removing intermediate container e008bd119324
```

Ref: http://oshanebailey.jamaicandevelopers.com/2017/10/11/error-could-not-determine-postgresql-version-10-0/

Otherwise, a couple of other libraries are updated according to the latest `requirements.txt`: https://github.com/odoo/odoo/blob/9e3c723c19e3889e589e9497236f80e09e5e612e/requirements.txt